### PR TITLE
Repo setup: branch protection, Dev Rel ownership, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
This PR is the last piece of a broader setup pass on this repo (2026-07-15). Only the dependabot config needed a PR - the rest was applied directly via repo/org settings and is documented here for visibility.

## Full set of changes

**1. Dev Rel team now owns the cookbook**
- Added @psinger-prior and @eliott-kalfon to the [`dev-rel`](https://github.com/orgs/PriorLabs/teams/dev-rel) team (Tuana was already in it).
- Granted `dev-rel` **maintain** access on this repo (it already had maintain on `docs`).

**2. CODEOWNERS** (committed directly to main, before protection was enabled)
- `.github/CODEOWNERS` with `* @PriorLabs/dev-rel` - every PR requires a Dev Rel review. Team-based rather than individual names, so team membership changes are picked up automatically.

**3. Branch protection ruleset "Protect main"** (active, same ruleset style as TabPFN / tabpfn-extensions)
- PRs required to change `main`, with 1 approval
- Code-owner (Dev Rel) review required
- Conversation resolution required before merge
- Force-pushes and branch deletion blocked
- No required status check yet: the only workflow ("Validate cookbooks") is path-filtered, so requiring it would block PRs that don't touch those paths. If an always-running CI job is added later, make it a required check in the ruleset.

**4. Repo description** set (was empty).

**5. This PR: dependabot for GitHub Actions**
- Weekly update PRs for pinned action versions, matching TabPFN / tabpfn-client / tabpfn-extensions.
- Pip is left out on purpose: `requirements.txt` pins notebook deps loosely and weekly bump PRs would be noise.

This PR merging is also the first live test of the new protection - it should require a Dev Rel approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)