### PR TITLE
chore: remove Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  # GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5


### PR DESCRIPTION
Removes `.github/dependabot.yml`.

### Why

The config only ever covered `github-actions`, and this repo has no dependency surface worth polling:

- the entire runtime dependency set is `PyYAML>=6.0`
- `scripts/validate.py` converts notebooks to MDX and checks frontmatter / author / Colab blocks; it does not execute them, so dependency versions are never exercised
- `[tool.uv] exclude-newer = "7 days"` deliberately makes the lock lag anyway

So the only thing it produced was major-version churn on a single workflow file.

### Those PRs could not merge anyway

The three open Dependabot PRs (#5, #7, #15) all fail `Publish Mintlify preview branch`, deterministically rather than flakily: Dependabot PRs run against a separate secret store, and this repo's is empty (`DOCS_REPO_TOKEN`, `MINTLIFY_API_KEY`, `MINTLIFY_PROJECT_ID` live in the Actions store). With the "Require PR approval on default branch (public repos)" ruleset on top, they sit permanently blocked. Copying a cross-repo write token into the Dependabot secret store to fix that is not worth it on a public repo.

### What stays on

Vulnerability alerts and automated security fixes are repository settings, not this file. Both remain enabled, currently 0 open alerts. They still cover PyYAML and the pinned actions if a real advisory lands, and they generate no PRs unless one does.

### Not addressed here

- #5, #7 and #15 are left open - close them, or merge the bumps once by hand first. `actions/checkout@v4` works today; the jump only matters when GitHub retires the runtime.
- If a recurring signal is wanted for a cookbook, the useful one is a scheduled job that actually runs the notebooks against the latest published `tabpfn`. Nothing does that today, so an API change rots the examples silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
