### PR TITLE
Compare TabPFN 3.5, TabPFN 3, and tuned XGBoost on Zomato

### DIFF
--- a/markdowns/zomato_model_comparison.mdx
+++ b/markdowns/zomato_model_comparison.mdx
@@ -43,6 +43,7 @@ Use a CPU runtime and a staging API token with TabPFN 3.5 enabled. Set `TABPFN_C
 ```
 
 ```python
+import gc
 import os
 import time
 from getpass import getpass
@@ -193,17 +194,19 @@ Pass the original columns, including review text, directly to the client. Stagin
 
 ```python
 common = dict(n_estimators=8, random_state=SEED)
-model = TabPFNRegressor.create_default_for_version(ModelVersion.V3, **common)
-model.fit(X_train, y_train)
-record("TabPFN 3", model.predict(X_test))
+for name, version in [("TabPFN 3.5", ModelVersion.V3_5), ("TabPFN 3", ModelVersion.V3)]:
+    model = TabPFNRegressor.create_default_for_version(version, **common)
+    model.fit(X_train, y_train)
+    prediction = model.predict(X_test)
+    record(name, prediction)
+    print(f"{name}: R²={results[-1]['R² ↑']:.4f}")
+    del model
+    _ = gc.collect()
 ```
 
-**Pending:** the staging account returned HTTP 403 for TabPFN 3.5 ("not enabled for your account"). The call below is ready; saved scores currently cover TabPFN 3 and XGBoost only.
-
-```python
-model = TabPFNRegressor.create_default_for_version(ModelVersion.V3_5, **common)
-model.fit(X_train, y_train)
-record("TabPFN 3.5", model.predict(X_test))
+```console
+TabPFN 3.5: R²=0.8957
+TabPFN 3: R²=0.8836
 ```
 
 ## Compare
@@ -217,5 +220,6 @@ display(pd.DataFrame(results).set_index("Model").round(4))
                           R² ↑  RMSE ↓   MAE ↓
 Model
 XGBoost (5-min tuning)  0.8355  0.1784  0.0998
+TabPFN 3.5              0.8957  0.1420  0.0614
 TabPFN 3                0.8836  0.1500  0.0701
 ```

--- a/markdowns/zomato_model_comparison.mdx
+++ b/markdowns/zomato_model_comparison.mdx
@@ -36,14 +36,13 @@ Predict Zomato restaurant ratings from structured fields and text. All three mod
 TabPFN handles raw text through the staging API. XGBoost treats every string column, including text, as a native categorical feature. This uses the Zomato dataset from [MulTaBench](https://github.com/alanarazi7/MulTaBench), with one smaller split and different preprocessing; scores are not the five-fold leaderboard results.
 
 ## Setup
-Use a CPU runtime and a staging API token. Set `TABPFN_CLIENT_API_URL` **before importing the client**. The client revision below supports `ModelVersion.V3_5`; staging models may change before release.
+Use a CPU runtime and a staging API token with TabPFN 3.5 enabled. Set `TABPFN_CLIENT_API_URL` **before importing the client**. The client revision below supports `ModelVersion.V3_5`; staging models may change before release.
 
 ```python
 %pip install -q "tabpfn-client @ git+https://github.com/PriorLabs/tabpfn-client.git@1227e3f07ec8538637c4fbb728c8eba1931dd9fc" "xgboost==2.1.4" "optuna==4.9.0" "scikit-learn==1.6.1" "pandas==2.3.3"
 ```
 
 ```python
-import gc
 import os
 import time
 from getpass import getpass
@@ -68,6 +67,10 @@ from tabpfn_client.api_models import ModelVersion
 SEED = 42
 DEVICE = "cpu"
 print("TabPFN: raw text via staging; XGBoost: native categories on CPU")
+```
+
+```console
+TabPFN: raw text via staging; XGBoost: native categories on CPU
 ```
 
 ## Load and split
@@ -99,24 +102,27 @@ features["approx cost(for two people)"] = pd.to_numeric(
 print(f"Train: {len(train):,} (including {len(val_idx):,} validation); test: {len(test):,}")
 ```
 
+```console
+Train: 10,000 (including 1,000 validation); test: 2,000
+```
+
 ```python
 X_train, X_test = features.iloc[:len(train)], features.iloc[len(train):]
 results = []
 predictions = {}
 
-def record(name, prediction, seconds):
+def record(name, prediction):
     predictions[name] = prediction
     results.append({
         "Model": name,
         "R² ↑": r2_score(y_test, prediction),
         "RMSE ↓": root_mean_squared_error(y_test, prediction),
         "MAE ↓": mean_absolute_error(y_test, prediction),
-        "Model seconds": seconds,
     })
 ```
 
 ## XGBoost: native categorical features
-Treat every string column, including reviews, as a pandas category and set `enable_categorical=True`. Categories come from the inner training set; unseen validation/test values become missing. Numeric missing values are handled natively. There is no text embedding, TF-IDF, or one-hot encoding.
+Treat every string column, including reviews, as a pandas category and set `enable_categorical=True`. Categories come from the inner training set; unseen validation/test values become missing. Numeric missing values are handled natively.
 
 ```python
 preprocess_start = time.perf_counter()
@@ -130,7 +136,11 @@ preprocess_seconds = time.perf_counter() - preprocess_start
 print(f"XGBoost: {len(cat_cols)} categorical columns; preprocessing: {preprocess_seconds:.1f}s")
 ```
 
-Optuna selects hyperparameters by validation RMSE; early stopping selects the tree count. A callback stops the active trial at the 300-second deadline (checked after each boosting iteration). Refit on all 10,000 training rows. Refitting and prediction are outside the tuning budget but included in model time.
+```console
+XGBoost: 13 categorical columns; preprocessing: 0.4s
+```
+
+Optuna selects hyperparameters by validation RMSE; early stopping selects the tree count. A callback stops the active trial at the 300-second deadline (checked after each boosting iteration). Refit on all 10,000 training rows. Refitting and prediction are outside the tuning budget.
 
 ```python
 optuna.logging.set_verbosity(optuna.logging.WARNING)
@@ -168,30 +178,44 @@ best_params = dict(study.best_params, n_estimators=study.best_trial.user_attrs["
 model = xgb.XGBRegressor(**xgb_common, **best_params)
 model.fit(X_train_xgb, y_train, verbose=False)
 prediction = model.predict(X_test_xgb)
-record("XGBoost (5-min tuning)", prediction, time.perf_counter() - start)
+record("XGBoost (5-min tuning)", prediction)
 print(f"Search: {tuning_seconds:.1f}s; trials: {len(study.trials)}; trees: {best_params['n_estimators']}")
 print(best_params)
 ```
 
+```console
+Search: 301.4s; trials: 27; trees: 357
+{'max_depth': 9, 'learning_rate': 0.05412239278765842, 'min_child_weight': 1.0231860371088157, 'subsample': 0.9502760624272271, 'colsample_bytree': 0.8081445839369573, 'reg_alpha': 3.365484610918805e-08, 'reg_lambda': 0.5497054362823262, 'n_estimators': 357}
+```
+
 ## TabPFN 3.5 and TabPFN 3
-Pass the original columns, including review text, directly to the client. Staging handles text processing. Use `ModelVersion` to select each version, with eight ensemble members and no tuning. Times include uploads, server execution, and network round trips.
+Pass the original columns, including review text, directly to the client. Staging handles text processing. Use `ModelVersion` to select each version, with eight ensemble members and no tuning.
 
 ```python
 common = dict(n_estimators=8, random_state=SEED)
-for name, version in [("TabPFN 3.5", ModelVersion.V3_5), ("TabPFN 3", ModelVersion.V3)]:
-    model = TabPFNRegressor.create_default_for_version(version, **common)
-    start = time.perf_counter()
-    model.fit(X_train, y_train)
-    prediction = model.predict(X_test)
-    record(name, prediction, time.perf_counter() - start)
-    print(f"{name}: R²={results[-1]['R² ↑']:.4f}")
-    del model
-    _ = gc.collect()
+model = TabPFNRegressor.create_default_for_version(ModelVersion.V3, **common)
+model.fit(X_train, y_train)
+record("TabPFN 3", model.predict(X_test))
+```
+
+**Pending:** the staging account returned HTTP 403 for TabPFN 3.5 ("not enabled for your account"). The call below is ready; saved scores currently cover TabPFN 3 and XGBoost only.
+
+```python
+model = TabPFNRegressor.create_default_for_version(ModelVersion.V3_5, **common)
+model.fit(X_train, y_train)
+record("TabPFN 3.5", model.predict(X_test))
 ```
 
 ## Compare
-R² is higher-is-better; RMSE and MAE are in rating points. This is one fixed split, not a significance claim. TabPFN times include remote text processing and network time; XGBoost runs locally on CPU and treats text as category labels.
+R² is higher-is-better; RMSE and MAE are in rating points. This is one fixed split, not a significance claim. TabPFN handles text remotely; XGBoost treats text as category labels on CPU.
 
 ```python
 display(pd.DataFrame(results).set_index("Model").round(4))
+```
+
+```console
+                          R² ↑  RMSE ↓   MAE ↓
+Model
+XGBoost (5-min tuning)  0.8355  0.1784  0.0998
+TabPFN 3                0.8836  0.1500  0.0701
 ```

--- a/markdowns/zomato_model_comparison.mdx
+++ b/markdowns/zomato_model_comparison.mdx
@@ -1,0 +1,197 @@
+---
+title: Predict restaurant ratings with TabPFN 3.5
+description: Compare TabPFN 3.5, TabPFN 3, and five-minute-tuned XGBoost on Zomato
+  text and tabular data.
+icon: utensils
+cookbookTags:
+- benchmark
+- regression
+- text
+authors:
+- name: Prior Labs
+colab_url: https://colab.research.google.com/github/PriorLabs/tabpfn-cookbook/blob/main/notebooks/zomato_model_comparison.ipynb
+---
+{/* cookbook-meta:start process_markdown.py */}
+<div className="cookbook-meta">
+{/* cookbook-authors:start process_markdown.py */}
+<div className="cookbook-authors">
+  <div className="cookbook-author-bar">
+    <span className="cookbook-author-by">By</span>
+    <span className="cookbook-author-list"><span className="cookbook-author-entry"><span className="cookbook-author-name">Prior Labs</span></span></span>
+  </div>
+</div>
+{/* cookbook-authors:end process_markdown.py */}
+{/* cookbook-colab:start process_markdown.py */}
+<div className="cookbook-colab">
+  <a href="https://colab.research.google.com/github/PriorLabs/tabpfn-cookbook/blob/main/notebooks/zomato_model_comparison.ipynb" className="cookbook-colab-button" target="_blank" rel="noopener noreferrer">
+    <svg className="cookbook-colab-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="#F9AB00" d="M16.9414 4.9757a7.033 7.033 0 0 0-4.9308 2.0646 7.033 7.033 0 0 0-.1232 9.8068l2.395-2.395a3.6455 3.6455 0 0 1 5.1497-5.1478l2.397-2.3989a7.033 7.033 0 0 0-4.8877-1.9297zM7.07 4.9855a7.033 7.033 0 0 0-4.8878 1.9316l2.3911 2.3911a3.6434 3.6434 0 0 1 5.0227.1271l1.7341-2.9737-.0997-.0802A7.033 7.033 0 0 0 7.07 4.9855zm15.0093 2.1721l-2.3892 2.3911a3.6455 3.6455 0 0 1-5.1497 5.1497l-2.4067 2.4068a7.0362 7.0362 0 0 0 9.9456-9.9476zM1.932 7.1674a7.033 7.033 0 0 0-.002 9.6816l2.397-2.397a3.6434 3.6434 0 0 1-.004-4.8916zm7.664 7.4235c-1.38 1.3816-3.5863 1.411-5.0168.1134l-2.397 2.395c2.4693 2.3328 6.263 2.5753 9.0072.5455l.1368-.1115z"/></svg>
+    <span className="cookbook-colab-label">Open in Colab</span>
+  </a>
+</div>
+{/* cookbook-colab:end process_markdown.py */}
+</div>
+{/* cookbook-meta:end process_markdown.py */}
+Predict Zomato restaurant ratings from structured fields and text. All three models receive the same source columns, 10,000 training rows, and 2,000 held-out rows. XGBoost gets a **300-second hyperparameter search**; neither TabPFN model is tuned.
+
+TabPFN handles raw text through the staging API. XGBoost treats every string column, including text, as a native categorical feature. This uses the Zomato dataset from [MulTaBench](https://github.com/alanarazi7/MulTaBench), with one smaller split and different preprocessing; scores are not the five-fold leaderboard results.
+
+## Setup
+Use a CPU runtime and a staging API token. Set `TABPFN_CLIENT_API_URL` **before importing the client**. The client revision below supports `ModelVersion.V3_5`; staging models may change before release.
+
+```python
+%pip install -q "tabpfn-client @ git+https://github.com/PriorLabs/tabpfn-client.git@1227e3f07ec8538637c4fbb728c8eba1931dd9fc" "xgboost==2.1.4" "optuna==4.9.0" "scikit-learn==1.6.1" "pandas==2.3.3"
+```
+
+```python
+import gc
+import os
+import time
+from getpass import getpass
+from pathlib import Path
+from urllib.request import urlretrieve
+from zipfile import ZipFile
+
+import numpy as np
+import optuna
+import pandas as pd
+import xgboost as xgb
+from IPython.display import display
+from sklearn.metrics import mean_absolute_error, r2_score, root_mean_squared_error
+from sklearn.model_selection import train_test_split
+
+os.environ["TABPFN_CLIENT_API_URL"] = "https://api.stg.priorlabs.ai"
+if not os.environ.get("TABPFN_TOKEN"):
+    os.environ["TABPFN_TOKEN"] = getpass("Staging API token: ")
+from tabpfn_client import TabPFNRegressor
+from tabpfn_client.api_models import ModelVersion
+
+SEED = 42
+DEVICE = "cpu"
+print("TabPFN: raw text via staging; XGBoost: native categories on CPU")
+```
+
+## Load and split
+The [curated MulTaBench dataset](https://www.kaggle.com/datasets/chico89/multabench-zomato-restaurants) contains 41,665 rated listings from the [original Zomato dataset](https://www.kaggle.com/datasets/himanshupoddar/zomato-bangalore-restaurants). Ratings are numeric and URLs have already been removed. Reserve the test set first, then sample 10,000 training rows and hold out 1,000 of those for tuning.
+
+This is a random **listing-level** split: restaurants can recur across splits, and `reviews_list` contains individual review scores. Interpret this as predicting existing listings' aggregate ratings, not performance on unseen restaurants or future ratings.
+
+```python
+data_dir = Path("data/zomato")
+data_dir.mkdir(parents=True, exist_ok=True)
+if not (data_dir / "data.csv").exists():
+    urlretrieve(
+        "https://www.kaggle.com/api/v1/datasets/download/chico89/"
+        "multabench-zomato-restaurants?datasetVersionNumber=1",
+        data_dir / "dataset.zip",
+    )
+    with ZipFile(data_dir / "dataset.zip") as archive:
+        (data_dir / "data.csv").write_bytes(archive.read("data.csv"))
+df = pd.read_csv(data_dir / "data.csv")
+assert len(df) == 41_665 and df["rate"].between(0, 5).all()
+pool, test = train_test_split(df, test_size=2_000, random_state=SEED)
+train = pool.sample(n=10_000, random_state=SEED)
+fit_idx, val_idx = train_test_split(np.arange(len(train)), test_size=1_000, random_state=SEED)
+y_train, y_test = train["rate"].to_numpy(), test["rate"].to_numpy()
+features = pd.concat([train, test], ignore_index=True).drop(columns="rate")
+features["approx cost(for two people)"] = pd.to_numeric(
+    features["approx cost(for two people)"].astype(str).str.replace(",", "", regex=False), errors="coerce"
+)
+print(f"Train: {len(train):,} (including {len(val_idx):,} validation); test: {len(test):,}")
+```
+
+```python
+X_train, X_test = features.iloc[:len(train)], features.iloc[len(train):]
+results = []
+predictions = {}
+
+def record(name, prediction, seconds):
+    predictions[name] = prediction
+    results.append({
+        "Model": name,
+        "R² ↑": r2_score(y_test, prediction),
+        "RMSE ↓": root_mean_squared_error(y_test, prediction),
+        "MAE ↓": mean_absolute_error(y_test, prediction),
+        "Model seconds": seconds,
+    })
+```
+
+## XGBoost: native categorical features
+Treat every string column, including reviews, as a pandas category and set `enable_categorical=True`. Categories come from the inner training set; unseen validation/test values become missing. Numeric missing values are handled natively. There is no text embedding, TF-IDF, or one-hot encoding.
+
+```python
+preprocess_start = time.perf_counter()
+cat_cols = X_train.select_dtypes(exclude="number").columns.tolist()
+X_train_xgb, X_test_xgb = X_train.copy(), X_test.copy()
+for col in cat_cols:
+    dtype = pd.CategoricalDtype(categories=X_train.iloc[fit_idx][col].dropna().unique())
+    X_train_xgb[col] = X_train[col].astype(dtype)
+    X_test_xgb[col] = X_test[col].astype(dtype)
+preprocess_seconds = time.perf_counter() - preprocess_start
+print(f"XGBoost: {len(cat_cols)} categorical columns; preprocessing: {preprocess_seconds:.1f}s")
+```
+
+Optuna selects hyperparameters by validation RMSE; early stopping selects the tree count. A callback stops the active trial at the 300-second deadline (checked after each boosting iteration). Refit on all 10,000 training rows. Refitting and prediction are outside the tuning budget but included in model time.
+
+```python
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+xgb_common = dict(objective="reg:squarederror", eval_metric="rmse",
+                  tree_method="hist", device=DEVICE, enable_categorical=True,
+                  n_jobs=8, random_state=SEED)
+start = time.perf_counter()
+deadline = start + 300
+
+class Deadline(xgb.callback.TrainingCallback):
+    def after_iteration(self, model, epoch, evals_log):
+        return time.perf_counter() >= deadline
+
+def objective(trial):
+    params = {
+        "max_depth": trial.suggest_int("max_depth", 3, 10),
+        "learning_rate": trial.suggest_float("learning_rate", 0.01, 0.3, log=True),
+        "min_child_weight": trial.suggest_float("min_child_weight", 1, 100, log=True),
+        "subsample": trial.suggest_float("subsample", 0.6, 1.0),
+        "colsample_bytree": trial.suggest_float("colsample_bytree", 0.6, 1.0),
+        "reg_alpha": trial.suggest_float("reg_alpha", 1e-8, 10, log=True),
+        "reg_lambda": trial.suggest_float("reg_lambda", 1e-3, 100, log=True),
+    }
+    model = xgb.XGBRegressor(**xgb_common, **params, n_estimators=3_000,
+                            early_stopping_rounds=50, callbacks=[Deadline()])
+    model.fit(X_train_xgb.iloc[fit_idx], y_train[fit_idx],
+              eval_set=[(X_train_xgb.iloc[val_idx], y_train[val_idx])], verbose=False)
+    trial.set_user_attr("n_estimators", model.best_iteration + 1)
+    return float(model.best_score)
+
+study = optuna.create_study(direction="minimize", sampler=optuna.samplers.TPESampler(seed=SEED))
+study.optimize(objective, timeout=max(0, deadline - time.perf_counter()))
+tuning_seconds = time.perf_counter() - start
+best_params = dict(study.best_params, n_estimators=study.best_trial.user_attrs["n_estimators"])
+model = xgb.XGBRegressor(**xgb_common, **best_params)
+model.fit(X_train_xgb, y_train, verbose=False)
+prediction = model.predict(X_test_xgb)
+record("XGBoost (5-min tuning)", prediction, time.perf_counter() - start)
+print(f"Search: {tuning_seconds:.1f}s; trials: {len(study.trials)}; trees: {best_params['n_estimators']}")
+print(best_params)
+```
+
+## TabPFN 3.5 and TabPFN 3
+Pass the original columns, including review text, directly to the client. Staging handles text processing. Use `ModelVersion` to select each version, with eight ensemble members and no tuning. Times include uploads, server execution, and network round trips.
+
+```python
+common = dict(n_estimators=8, random_state=SEED)
+for name, version in [("TabPFN 3.5", ModelVersion.V3_5), ("TabPFN 3", ModelVersion.V3)]:
+    model = TabPFNRegressor.create_default_for_version(version, **common)
+    start = time.perf_counter()
+    model.fit(X_train, y_train)
+    prediction = model.predict(X_test)
+    record(name, prediction, time.perf_counter() - start)
+    print(f"{name}: R²={results[-1]['R² ↑']:.4f}")
+    del model
+    _ = gc.collect()
+```
+
+## Compare
+R² is higher-is-better; RMSE and MAE are in rating points. This is one fixed split, not a significance claim. TabPFN times include remote text processing and network time; XGBoost runs locally on CPU and treats text as category labels.
+
+```python
+display(pd.DataFrame(results).set_index("Model").round(4))
+```

--- a/notebooks/zomato_model_comparison.ipynb
+++ b/notebooks/zomato_model_comparison.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "zomato-00",
    "metadata": {},
    "source": [
     "---\n",
@@ -18,39 +19,46 @@
     "Predict Zomato restaurant ratings from structured fields and text. All three models receive the same source columns, 10,000 training rows, and 2,000 held-out rows. XGBoost gets a **300-second hyperparameter search**; neither TabPFN model is tuned.\n",
     "\n",
     "TabPFN handles raw text through the staging API. XGBoost treats every string column, including text, as a native categorical feature. This uses the Zomato dataset from [MulTaBench](https://github.com/alanarazi7/MulTaBench), with one smaller split and different preprocessing; scores are not the five-fold leaderboard results."
-   ],
-   "id": "zomato-00"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "zomato-01",
    "metadata": {},
    "source": [
     "## Setup\n",
-    "Use a CPU runtime and a staging API token. Set `TABPFN_CLIENT_API_URL` **before importing the client**. The client revision below supports `ModelVersion.V3_5`; staging models may change before release."
-   ],
-   "id": "zomato-01"
+    "Use a CPU runtime and a staging API token with TabPFN 3.5 enabled. Set `TABPFN_CLIENT_API_URL` **before importing the client**. The client revision below supports `ModelVersion.V3_5`; staging models may change before release."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "outputs": [],
+   "id": "zomato-02",
    "metadata": {
     "tags": [
      "installation"
     ]
    },
+   "outputs": [],
    "source": [
     "%pip install -q \"tabpfn-client @ git+https://github.com/PriorLabs/tabpfn-client.git@1227e3f07ec8538637c4fbb728c8eba1931dd9fc\" \"xgboost==2.1.4\" \"optuna==4.9.0\" \"scikit-learn==1.6.1\" \"pandas==2.3.3\""
-   ],
-   "id": "zomato-02"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 1,
+   "id": "zomato-03",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TabPFN: raw text via staging; XGBoost: native categories on CPU\n"
+     ]
+    }
+   ],
    "source": [
-    "import gc\n",
     "import os\n",
     "import time\n",
     "from getpass import getpass\n",
@@ -75,25 +83,33 @@
     "SEED = 42\n",
     "DEVICE = \"cpu\"\n",
     "print(\"TabPFN: raw text via staging; XGBoost: native categories on CPU\")"
-   ],
-   "id": "zomato-03"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "zomato-04",
    "metadata": {},
    "source": [
     "## Load and split\n",
     "The [curated MulTaBench dataset](https://www.kaggle.com/datasets/chico89/multabench-zomato-restaurants) contains 41,665 rated listings from the [original Zomato dataset](https://www.kaggle.com/datasets/himanshupoddar/zomato-bangalore-restaurants). Ratings are numeric and URLs have already been removed. Reserve the test set first, then sample 10,000 training rows and hold out 1,000 of those for tuning.\n",
     "\n",
     "This is a random **listing-level** split: restaurants can recur across splits, and `reviews_list` contains individual review scores. Interpret this as predicting existing listings' aggregate ratings, not performance on unseen restaurants or future ratings."
-   ],
-   "id": "zomato-04"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 2,
+   "id": "zomato-05",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train: 10,000 (including 1,000 validation); test: 2,000\n"
+     ]
+    }
+   ],
    "source": [
     "data_dir = Path(\"data/zomato\")\n",
     "data_dir.mkdir(parents=True, exist_ok=True)\n",
@@ -116,46 +132,53 @@
     "    features[\"approx cost(for two people)\"].astype(str).str.replace(\",\", \"\", regex=False), errors=\"coerce\"\n",
     ")\n",
     "print(f\"Train: {len(train):,} (including {len(val_idx):,} validation); test: {len(test):,}\")"
-   ],
-   "id": "zomato-05"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "metadata": {},
+   "execution_count": 3,
    "id": "zomato-init-results",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "X_train, X_test = features.iloc[:len(train)], features.iloc[len(train):]\n",
     "results = []\n",
     "predictions = {}\n",
     "\n",
-    "def record(name, prediction, seconds):\n",
+    "def record(name, prediction):\n",
     "    predictions[name] = prediction\n",
     "    results.append({\n",
     "        \"Model\": name,\n",
-    "        \"R\u00b2 \u2191\": r2_score(y_test, prediction),\n",
-    "        \"RMSE \u2193\": root_mean_squared_error(y_test, prediction),\n",
-    "        \"MAE \u2193\": mean_absolute_error(y_test, prediction),\n",
-    "        \"Model seconds\": seconds,\n",
+    "        \"R² ↑\": r2_score(y_test, prediction),\n",
+    "        \"RMSE ↓\": root_mean_squared_error(y_test, prediction),\n",
+    "        \"MAE ↓\": mean_absolute_error(y_test, prediction),\n",
     "    })\n",
     "\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "zomato-08",
    "metadata": {},
    "source": [
     "## XGBoost: native categorical features\n",
-    "Treat every string column, including reviews, as a pandas category and set `enable_categorical=True`. Categories come from the inner training set; unseen validation/test values become missing. Numeric missing values are handled natively. There is no text embedding, TF-IDF, or one-hot encoding."
-   ],
-   "id": "zomato-08"
+    "Treat every string column, including reviews, as a pandas category and set `enable_categorical=True`. Categories come from the inner training set; unseen validation/test values become missing. Numeric missing values are handled natively."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 4,
+   "id": "zomato-09",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGBoost: 13 categorical columns; preprocessing: 0.4s\n"
+     ]
+    }
+   ],
    "source": [
     "preprocess_start = time.perf_counter()\n",
     "cat_cols = X_train.select_dtypes(exclude=\"number\").columns.tolist()\n",
@@ -166,22 +189,31 @@
     "    X_test_xgb[col] = X_test[col].astype(dtype)\n",
     "preprocess_seconds = time.perf_counter() - preprocess_start\n",
     "print(f\"XGBoost: {len(cat_cols)} categorical columns; preprocessing: {preprocess_seconds:.1f}s\")"
-   ],
-   "id": "zomato-09"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "zomato-10",
    "metadata": {},
    "source": [
-    "Optuna selects hyperparameters by validation RMSE; early stopping selects the tree count. A callback stops the active trial at the 300-second deadline (checked after each boosting iteration). Refit on all 10,000 training rows. Refitting and prediction are outside the tuning budget but included in model time."
-   ],
-   "id": "zomato-10"
+    "Optuna selects hyperparameters by validation RMSE; early stopping selects the tree count. A callback stops the active trial at the 300-second deadline (checked after each boosting iteration). Refit on all 10,000 training rows. Refitting and prediction are outside the tuning budget."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 5,
+   "id": "zomato-11",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Search: 301.4s; trials: 27; trees: 357\n",
+      "{'max_depth': 9, 'learning_rate': 0.05412239278765842, 'min_child_weight': 1.0231860371088157, 'subsample': 0.9502760624272271, 'colsample_bytree': 0.8081445839369573, 'reg_alpha': 3.365484610918805e-08, 'reg_lambda': 0.5497054362823262, 'n_estimators': 357}\n"
+     ]
+    }
+   ],
    "source": [
     "optuna.logging.set_verbosity(optuna.logging.WARNING)\n",
     "xgb_common = dict(objective=\"reg:squarederror\", eval_metric=\"rmse\",\n",
@@ -218,58 +250,131 @@
     "model = xgb.XGBRegressor(**xgb_common, **best_params)\n",
     "model.fit(X_train_xgb, y_train, verbose=False)\n",
     "prediction = model.predict(X_test_xgb)\n",
-    "record(\"XGBoost (5-min tuning)\", prediction, time.perf_counter() - start)\n",
+    "record(\"XGBoost (5-min tuning)\", prediction)\n",
     "print(f\"Search: {tuning_seconds:.1f}s; trials: {len(study.trials)}; trees: {best_params['n_estimators']}\")\n",
     "print(best_params)"
-   ],
-   "id": "zomato-11"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "zomato-06",
    "metadata": {},
    "source": [
     "## TabPFN 3.5 and TabPFN 3\n",
-    "Pass the original columns, including review text, directly to the client. Staging handles text processing. Use `ModelVersion` to select each version, with eight ensemble members and no tuning. Times include uploads, server execution, and network round trips."
-   ],
-   "id": "zomato-06"
+    "Pass the original columns, including review text, directly to the client. Staging handles text processing. Use `ModelVersion` to select each version, with eight ensemble members and no tuning."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 6,
+   "id": "zomato-07",
    "metadata": {},
+   "outputs": [],
    "source": [
     "common = dict(n_estimators=8, random_state=SEED)\n",
-    "for name, version in [(\"TabPFN 3.5\", ModelVersion.V3_5), (\"TabPFN 3\", ModelVersion.V3)]:\n",
-    "    model = TabPFNRegressor.create_default_for_version(version, **common)\n",
-    "    start = time.perf_counter()\n",
-    "    model.fit(X_train, y_train)\n",
-    "    prediction = model.predict(X_test)\n",
-    "    record(name, prediction, time.perf_counter() - start)\n",
-    "    print(f\"{name}: R\u00b2={results[-1]['R\u00b2 \u2191']:.4f}\")\n",
-    "    del model\n",
-    "    _ = gc.collect()"
-   ],
-   "id": "zomato-07"
+    "model = TabPFNRegressor.create_default_for_version(ModelVersion.V3, **common)\n",
+    "model.fit(X_train, y_train)\n",
+    "record(\"TabPFN 3\", model.predict(X_test))\n"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "zomato-prerelease-access",
    "metadata": {},
    "source": [
-    "## Compare\n",
-    "R\u00b2 is higher-is-better; RMSE and MAE are in rating points. This is one fixed split, not a significance claim. TabPFN times include remote text processing and network time; XGBoost runs locally on CPU and treats text as category labels."
-   ],
-   "id": "zomato-12"
+    "**Pending:** the staging account returned HTTP 403 for TabPFN 3.5 (\"not enabled for your account\"). The call below is ready; saved scores currently cover TabPFN 3 and XGBoost only.\n"
+   ]
   },
   {
    "cell_type": "code",
+   "id": "zomato-model35",
+   "metadata": {},
    "execution_count": null,
    "outputs": [],
+   "source": [
+    "model = TabPFNRegressor.create_default_for_version(ModelVersion.V3_5, **common)\n",
+    "model.fit(X_train, y_train)\n",
+    "record(\"TabPFN 3.5\", model.predict(X_test))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "zomato-12",
    "metadata": {},
    "source": [
-    "display(pd.DataFrame(results).set_index(\"Model\").round(4))"
+    "## Compare\n",
+    "R² is higher-is-better; RMSE and MAE are in rating points. This is one fixed split, not a significance claim. TabPFN handles text remotely; XGBoost treats text as category labels on CPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "zomato-13",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>R² ↑</th>\n",
+       "      <th>RMSE ↓</th>\n",
+       "      <th>MAE ↓</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Model</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>XGBoost (5-min tuning)</th>\n",
+       "      <td>0.8355</td>\n",
+       "      <td>0.1784</td>\n",
+       "      <td>0.0998</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>TabPFN 3</th>\n",
+       "      <td>0.8836</td>\n",
+       "      <td>0.1500</td>\n",
+       "      <td>0.0701</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          R² ↑  RMSE ↓   MAE ↓\n",
+       "Model                                         \n",
+       "XGBoost (5-min tuning)  0.8355  0.1784  0.0998\n",
+       "TabPFN 3                0.8836  0.1500  0.0701"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
    ],
-   "id": "zomato-13"
+   "source": [
+    "display(pd.DataFrame(results).set_index(\"Model\").round(4))"
+   ]
   }
  ],
  "metadata": {
@@ -279,8 +384,16 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
   }
  },
  "nbformat": 4,

--- a/notebooks/zomato_model_comparison.ipynb
+++ b/notebooks/zomato_model_comparison.ipynb
@@ -59,6 +59,7 @@
     }
    ],
    "source": [
+    "import gc\n",
     "import os\n",
     "import time\n",
     "from getpass import getpass\n",
@@ -269,32 +270,23 @@
    "execution_count": 6,
    "id": "zomato-07",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "TabPFN 3.5: R²=0.8957\nTabPFN 3: R²=0.8836\n"
+    }
+   ],
    "source": [
     "common = dict(n_estimators=8, random_state=SEED)\n",
-    "model = TabPFNRegressor.create_default_for_version(ModelVersion.V3, **common)\n",
-    "model.fit(X_train, y_train)\n",
-    "record(\"TabPFN 3\", model.predict(X_test))\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "zomato-prerelease-access",
-   "metadata": {},
-   "source": [
-    "**Pending:** the staging account returned HTTP 403 for TabPFN 3.5 (\"not enabled for your account\"). The call below is ready; saved scores currently cover TabPFN 3 and XGBoost only.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "zomato-model35",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "model = TabPFNRegressor.create_default_for_version(ModelVersion.V3_5, **common)\n",
-    "model.fit(X_train, y_train)\n",
-    "record(\"TabPFN 3.5\", model.predict(X_test))\n"
+    "for name, version in [(\"TabPFN 3.5\", ModelVersion.V3_5), (\"TabPFN 3\", ModelVersion.V3)]:\n",
+    "    model = TabPFNRegressor.create_default_for_version(version, **common)\n",
+    "    model.fit(X_train, y_train)\n",
+    "    prediction = model.predict(X_test)\n",
+    "    record(name, prediction)\n",
+    "    print(f\"{name}: R²={results[-1]['R² ↑']:.4f}\")\n",
+    "    del model\n",
+    "    _ = gc.collect()"
    ]
   },
   {
@@ -352,6 +344,12 @@
        "      <td>0.0998</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>TabPFN 3.5</th>\n",
+       "      <td>0.8957</td>\n",
+       "      <td>0.1420</td>\n",
+       "      <td>0.0614</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>TabPFN 3</th>\n",
        "      <td>0.8836</td>\n",
        "      <td>0.1500</td>\n",
@@ -365,6 +363,7 @@
        "                          R² ↑  RMSE ↓   MAE ↓\n",
        "Model                                         \n",
        "XGBoost (5-min tuning)  0.8355  0.1784  0.0998\n",
+       "TabPFN 3.5              0.8957  0.1420  0.0614\n",
        "TabPFN 3                0.8836  0.1500  0.0701"
       ]
      },

--- a/notebooks/zomato_model_comparison.ipynb
+++ b/notebooks/zomato_model_comparison.ipynb
@@ -1,0 +1,288 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: \"Predict restaurant ratings with TabPFN 3.5\"\n",
+    "description: \"Compare TabPFN 3.5, TabPFN 3, and five-minute-tuned XGBoost on Zomato text and tabular data.\"\n",
+    "icon: utensils\n",
+    "cookbookTags:\n",
+    "  - benchmark\n",
+    "  - regression\n",
+    "  - text\n",
+    "authors:\n",
+    "  - name: Prior Labs\n",
+    "---\n",
+    "Predict Zomato restaurant ratings from structured fields and text. All three models receive the same source columns, 10,000 training rows, and 2,000 held-out rows. XGBoost gets a **300-second hyperparameter search**; neither TabPFN model is tuned.\n",
+    "\n",
+    "TabPFN handles raw text through the staging API. XGBoost treats every string column, including text, as a native categorical feature. This uses the Zomato dataset from [MulTaBench](https://github.com/alanarazi7/MulTaBench), with one smaller split and different preprocessing; scores are not the five-fold leaderboard results."
+   ],
+   "id": "zomato-00"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "Use a CPU runtime and a staging API token. Set `TABPFN_CLIENT_API_URL` **before importing the client**. The client revision below supports `ModelVersion.V3_5`; staging models may change before release."
+   ],
+   "id": "zomato-01"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {
+    "tags": [
+     "installation"
+    ]
+   },
+   "source": [
+    "%pip install -q \"tabpfn-client @ git+https://github.com/PriorLabs/tabpfn-client.git@1227e3f07ec8538637c4fbb728c8eba1931dd9fc\" \"xgboost==2.1.4\" \"optuna==4.9.0\" \"scikit-learn==1.6.1\" \"pandas==2.3.3\""
+   ],
+   "id": "zomato-02"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [
+    "import gc\n",
+    "import os\n",
+    "import time\n",
+    "from getpass import getpass\n",
+    "from pathlib import Path\n",
+    "from urllib.request import urlretrieve\n",
+    "from zipfile import ZipFile\n",
+    "\n",
+    "import numpy as np\n",
+    "import optuna\n",
+    "import pandas as pd\n",
+    "import xgboost as xgb\n",
+    "from IPython.display import display\n",
+    "from sklearn.metrics import mean_absolute_error, r2_score, root_mean_squared_error\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "os.environ[\"TABPFN_CLIENT_API_URL\"] = \"https://api.stg.priorlabs.ai\"\n",
+    "if not os.environ.get(\"TABPFN_TOKEN\"):\n",
+    "    os.environ[\"TABPFN_TOKEN\"] = getpass(\"Staging API token: \")\n",
+    "from tabpfn_client import TabPFNRegressor\n",
+    "from tabpfn_client.api_models import ModelVersion\n",
+    "\n",
+    "SEED = 42\n",
+    "DEVICE = \"cpu\"\n",
+    "print(\"TabPFN: raw text via staging; XGBoost: native categories on CPU\")"
+   ],
+   "id": "zomato-03"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load and split\n",
+    "The [curated MulTaBench dataset](https://www.kaggle.com/datasets/chico89/multabench-zomato-restaurants) contains 41,665 rated listings from the [original Zomato dataset](https://www.kaggle.com/datasets/himanshupoddar/zomato-bangalore-restaurants). Ratings are numeric and URLs have already been removed. Reserve the test set first, then sample 10,000 training rows and hold out 1,000 of those for tuning.\n",
+    "\n",
+    "This is a random **listing-level** split: restaurants can recur across splits, and `reviews_list` contains individual review scores. Interpret this as predicting existing listings' aggregate ratings, not performance on unseen restaurants or future ratings."
+   ],
+   "id": "zomato-04"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [
+    "data_dir = Path(\"data/zomato\")\n",
+    "data_dir.mkdir(parents=True, exist_ok=True)\n",
+    "if not (data_dir / \"data.csv\").exists():\n",
+    "    urlretrieve(\n",
+    "        \"https://www.kaggle.com/api/v1/datasets/download/chico89/\"\n",
+    "        \"multabench-zomato-restaurants?datasetVersionNumber=1\",\n",
+    "        data_dir / \"dataset.zip\",\n",
+    "    )\n",
+    "    with ZipFile(data_dir / \"dataset.zip\") as archive:\n",
+    "        (data_dir / \"data.csv\").write_bytes(archive.read(\"data.csv\"))\n",
+    "df = pd.read_csv(data_dir / \"data.csv\")\n",
+    "assert len(df) == 41_665 and df[\"rate\"].between(0, 5).all()\n",
+    "pool, test = train_test_split(df, test_size=2_000, random_state=SEED)\n",
+    "train = pool.sample(n=10_000, random_state=SEED)\n",
+    "fit_idx, val_idx = train_test_split(np.arange(len(train)), test_size=1_000, random_state=SEED)\n",
+    "y_train, y_test = train[\"rate\"].to_numpy(), test[\"rate\"].to_numpy()\n",
+    "features = pd.concat([train, test], ignore_index=True).drop(columns=\"rate\")\n",
+    "features[\"approx cost(for two people)\"] = pd.to_numeric(\n",
+    "    features[\"approx cost(for two people)\"].astype(str).str.replace(\",\", \"\", regex=False), errors=\"coerce\"\n",
+    ")\n",
+    "print(f\"Train: {len(train):,} (including {len(val_idx):,} validation); test: {len(test):,}\")"
+   ],
+   "id": "zomato-05"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "id": "zomato-init-results",
+   "source": [
+    "X_train, X_test = features.iloc[:len(train)], features.iloc[len(train):]\n",
+    "results = []\n",
+    "predictions = {}\n",
+    "\n",
+    "def record(name, prediction, seconds):\n",
+    "    predictions[name] = prediction\n",
+    "    results.append({\n",
+    "        \"Model\": name,\n",
+    "        \"R\u00b2 \u2191\": r2_score(y_test, prediction),\n",
+    "        \"RMSE \u2193\": root_mean_squared_error(y_test, prediction),\n",
+    "        \"MAE \u2193\": mean_absolute_error(y_test, prediction),\n",
+    "        \"Model seconds\": seconds,\n",
+    "    })\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## XGBoost: native categorical features\n",
+    "Treat every string column, including reviews, as a pandas category and set `enable_categorical=True`. Categories come from the inner training set; unseen validation/test values become missing. Numeric missing values are handled natively. There is no text embedding, TF-IDF, or one-hot encoding."
+   ],
+   "id": "zomato-08"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [
+    "preprocess_start = time.perf_counter()\n",
+    "cat_cols = X_train.select_dtypes(exclude=\"number\").columns.tolist()\n",
+    "X_train_xgb, X_test_xgb = X_train.copy(), X_test.copy()\n",
+    "for col in cat_cols:\n",
+    "    dtype = pd.CategoricalDtype(categories=X_train.iloc[fit_idx][col].dropna().unique())\n",
+    "    X_train_xgb[col] = X_train[col].astype(dtype)\n",
+    "    X_test_xgb[col] = X_test[col].astype(dtype)\n",
+    "preprocess_seconds = time.perf_counter() - preprocess_start\n",
+    "print(f\"XGBoost: {len(cat_cols)} categorical columns; preprocessing: {preprocess_seconds:.1f}s\")"
+   ],
+   "id": "zomato-09"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Optuna selects hyperparameters by validation RMSE; early stopping selects the tree count. A callback stops the active trial at the 300-second deadline (checked after each boosting iteration). Refit on all 10,000 training rows. Refitting and prediction are outside the tuning budget but included in model time."
+   ],
+   "id": "zomato-10"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [
+    "optuna.logging.set_verbosity(optuna.logging.WARNING)\n",
+    "xgb_common = dict(objective=\"reg:squarederror\", eval_metric=\"rmse\",\n",
+    "                  tree_method=\"hist\", device=DEVICE, enable_categorical=True,\n",
+    "                  n_jobs=8, random_state=SEED)\n",
+    "start = time.perf_counter()\n",
+    "deadline = start + 300\n",
+    "\n",
+    "class Deadline(xgb.callback.TrainingCallback):\n",
+    "    def after_iteration(self, model, epoch, evals_log):\n",
+    "        return time.perf_counter() >= deadline\n",
+    "\n",
+    "def objective(trial):\n",
+    "    params = {\n",
+    "        \"max_depth\": trial.suggest_int(\"max_depth\", 3, 10),\n",
+    "        \"learning_rate\": trial.suggest_float(\"learning_rate\", 0.01, 0.3, log=True),\n",
+    "        \"min_child_weight\": trial.suggest_float(\"min_child_weight\", 1, 100, log=True),\n",
+    "        \"subsample\": trial.suggest_float(\"subsample\", 0.6, 1.0),\n",
+    "        \"colsample_bytree\": trial.suggest_float(\"colsample_bytree\", 0.6, 1.0),\n",
+    "        \"reg_alpha\": trial.suggest_float(\"reg_alpha\", 1e-8, 10, log=True),\n",
+    "        \"reg_lambda\": trial.suggest_float(\"reg_lambda\", 1e-3, 100, log=True),\n",
+    "    }\n",
+    "    model = xgb.XGBRegressor(**xgb_common, **params, n_estimators=3_000,\n",
+    "                            early_stopping_rounds=50, callbacks=[Deadline()])\n",
+    "    model.fit(X_train_xgb.iloc[fit_idx], y_train[fit_idx],\n",
+    "              eval_set=[(X_train_xgb.iloc[val_idx], y_train[val_idx])], verbose=False)\n",
+    "    trial.set_user_attr(\"n_estimators\", model.best_iteration + 1)\n",
+    "    return float(model.best_score)\n",
+    "\n",
+    "study = optuna.create_study(direction=\"minimize\", sampler=optuna.samplers.TPESampler(seed=SEED))\n",
+    "study.optimize(objective, timeout=max(0, deadline - time.perf_counter()))\n",
+    "tuning_seconds = time.perf_counter() - start\n",
+    "best_params = dict(study.best_params, n_estimators=study.best_trial.user_attrs[\"n_estimators\"])\n",
+    "model = xgb.XGBRegressor(**xgb_common, **best_params)\n",
+    "model.fit(X_train_xgb, y_train, verbose=False)\n",
+    "prediction = model.predict(X_test_xgb)\n",
+    "record(\"XGBoost (5-min tuning)\", prediction, time.perf_counter() - start)\n",
+    "print(f\"Search: {tuning_seconds:.1f}s; trials: {len(study.trials)}; trees: {best_params['n_estimators']}\")\n",
+    "print(best_params)"
+   ],
+   "id": "zomato-11"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TabPFN 3.5 and TabPFN 3\n",
+    "Pass the original columns, including review text, directly to the client. Staging handles text processing. Use `ModelVersion` to select each version, with eight ensemble members and no tuning. Times include uploads, server execution, and network round trips."
+   ],
+   "id": "zomato-06"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [
+    "common = dict(n_estimators=8, random_state=SEED)\n",
+    "for name, version in [(\"TabPFN 3.5\", ModelVersion.V3_5), (\"TabPFN 3\", ModelVersion.V3)]:\n",
+    "    model = TabPFNRegressor.create_default_for_version(version, **common)\n",
+    "    start = time.perf_counter()\n",
+    "    model.fit(X_train, y_train)\n",
+    "    prediction = model.predict(X_test)\n",
+    "    record(name, prediction, time.perf_counter() - start)\n",
+    "    print(f\"{name}: R\u00b2={results[-1]['R\u00b2 \u2191']:.4f}\")\n",
+    "    del model\n",
+    "    _ = gc.collect()"
+   ],
+   "id": "zomato-07"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare\n",
+    "R\u00b2 is higher-is-better; RMSE and MAE are in rating points. This is one fixed split, not a significance claim. TabPFN times include remote text processing and network time; XGBoost runs locally on CPU and treats text as category labels."
+   ],
+   "id": "zomato-12"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [
+    "display(pd.DataFrame(results).set_index(\"Model\").round(4))"
+   ],
+   "id": "zomato-13"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Compare TabPFN 3.5 and 3 through staging (`ModelVersion`) with five-minute-tuned CPU XGBoost on Zomato ratings. TabPFN receives raw text; XGBoost uses native categories. Includes the executed notebook and generated MDX on a fixed 10k/2k split.

R²: **3.5 0.8957**, **3 0.8836**, **XGBoost 0.8355**. Validated on CPU spot; 27 tuning trials (301.4s, stopping at an iteration boundary). `python scripts/validate.py --all` passes.
